### PR TITLE
Fix `decodeStream` behavior on incomplete data

### DIFF
--- a/Decoder.ts
+++ b/Decoder.ts
@@ -97,6 +97,10 @@ export class Decoder<ContextType> {
   }
 
   private appendBuffer(buffer: ArrayLike<number>) {
+    // Create a fresh copy of `buffer` while caller might re-use and
+    // modify the content of the `buffer`.
+    // This cause data pollution issue like #2.
+    buffer = ensureUint8Array(buffer).slice();
     if (this.headByte === HEAD_BYTE_REQUIRED && !this.hasRemaining()) {
       this.setBuffer(buffer);
     } else {

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -1,0 +1,25 @@
+import { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
+
+import { decodeStream, encode } from "../mod.ts";
+
+Deno.test("Test decodeStream properly handle complete data", async () => {
+  const reader = new Deno.Buffer(encode("0123456789"));
+  const stream = Deno.iter(reader, { bufSize: 10 });
+  const result = await consumeAll(decodeStream(stream));
+  assertEquals(result, ["0123456789"]);
+});
+
+Deno.test("Test decodeStream properly handle incomplete data", async () => {
+  const reader = new Deno.Buffer(encode("0123456789"));
+  const stream = Deno.iter(reader, { bufSize: 8 });
+  const result = await consumeAll(decodeStream(stream));
+  assertEquals(result, ["0123456789"]);
+});
+
+async function consumeAll<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const result = [];
+  for await (const item of it) {
+    result.push(item);
+  }
+  return result;
+}


### PR DESCRIPTION
Thanks for the great library. I've found that `decodeStream` fails to decode incomplete data thus I've added a test which fails with the current implementation.

I haven't successes to fix the issue but I thought it might be worth to create an incomplete PR.

Now the test fails with the following messages

```
Check file:///Users/alisue/ghq/github.com/lambdalisue/msgpack-deno/$deno$test.ts
running 3 tests
test Test decodeStream properly handle complete data ... ok (4ms)
test Test decodeStream properly handle incomplete data ... FAILED (3ms)
test Test encode/decode ... ok (3ms)

failures:

Test decodeStream properly handle incomplete data
AssertionError: Values are not equal:


    [Diff] Actual / Expected


    [
-     "8923456789",
+     "0123456789",
    ]

    at assertEquals (https://deno.land/std@0.68.0/testing/asserts.ts:200:9)
    at file:///Users/alisue/ghq/github.com/lambdalisue/msgpack-deno/tests/stream_test.ts:16:3
    at async asyncOpSanitizer (deno:runtime/js/40_testing.js:37:9)
    at async resourceSanitizer (deno:runtime/js/40_testing.js:73:7)
    at async Object.exitSanitizer [as fn] (deno:runtime/js/40_testing.js:100:9)
    at async TestRunner.[Symbol.asyncIterator] (deno:runtime/js/40_testing.js:272:13)
    at async Object.runTests (deno:runtime/js/40_testing.js:347:22)
    at async file:///Users/alisue/ghq/github.com/lambdalisue/msgpack-deno/$deno$test.ts:4:1

failures:

        Test decodeStream properly handle incomplete data

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out (10ms)

```