### PR TITLE
Fix Encoder initialization

### DIFF
--- a/Encoder.ts
+++ b/Encoder.ts
@@ -14,8 +14,8 @@ export const DEFAULT_INITIAL_BUFFER_SIZE = 2048;
 
 export class Encoder<ContextType> {
   private pos = 0;
-  private view = new DataView(new ArrayBuffer(this.initialBufferSize));
-  private bytes = new Uint8Array(this.view.buffer);
+  private view;
+  private bytes;
 
   public constructor(
     private readonly extensionCodec: ExtensionCodecType<ContextType> =
@@ -26,7 +26,10 @@ export class Encoder<ContextType> {
     private readonly sortKeys = false,
     private readonly forceFloat32 = false,
     private readonly ignoreUndefined = false,
-  ) {}
+  ) {
+    this.view = new DataView(new ArrayBuffer(this.initialBufferSize));
+    this.bytes = new Uint8Array(this.view.buffer);
+  }
 
   private getUint8Array(): Uint8Array {
     return this.bytes.subarray(0, this.pos);

--- a/mod.ts
+++ b/mod.ts
@@ -18,8 +18,8 @@ export { Encoder } from "./Encoder.ts";
 
 // Utilitiies for Extension Types:
 
+export { ExtensionCodec } from "./ExtensionCodec.ts";
 export type {
-  ExtensionCodec,
   ExtensionCodecType,
   ExtensionDecoderType,
   ExtensionEncoderType,


### PR DESCRIPTION
Something seems to have changed in the bundled typescript with the latest deno. Without this change, the following occurs:

```
➜  msgpack-deno git:(master) deno run mod.ts                            
Check file:///Users/andrew/workspaces/msgpack-deno/mod.ts
error: TS2729 [ERROR]: Property 'initialBufferSize' is used before its initialization.
  private view = new DataView(new ArrayBuffer(this.initialBufferSize));
                                                   ~~~~~~~~~~~~~~~~~
    at file:///Users/andrew/workspaces/msgpack-deno/Encoder.ts:17:52

    'initialBufferSize' is declared here.
        private readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        at file:///Users/andrew/workspaces/msgpack-deno/Encoder.ts:25:5
```

This PR fixes that issue.