### PR TITLE
Fix export of ExtensionCodec

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -18,8 +18,8 @@ export { Encoder } from "./Encoder.ts";
 
 // Utilitiies for Extension Types:
 
+export { ExtensionCodec } from "./ExtensionCodec.ts";
 export type {
-  ExtensionCodec,
   ExtensionCodecType,
   ExtensionDecoderType,
   ExtensionEncoderType,


### PR DESCRIPTION
The official docs describe creating an extension codec like this:

```ts
import { encode, decode, ExtensionCodec } from "@msgpack/msgpack";

const extensionCodec = new ExtensionCodec();
```

Therefore `ExtensionCodec` needs to be exported not just as a type.