### PR TITLE
Add GitHub Actions, original tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Test
+
+env:
+  DENO_VERSION: 1.x
+
+on:
+  schedule:
+    - cron: '0 7 * * 0'
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+      - name: Lint
+        run: deno lint --unstable
+
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+      - name: Format
+        run: |
+          deno fmt
+          git diff --exit-code
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denoland/setup-deno@main
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+      - name: Test
+        run: |
+          deno test

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "deno.enable": true,
+  "deno.enable": true
 }

--- a/Decoder.ts
+++ b/Decoder.ts
@@ -2,8 +2,8 @@ import { prettyByte } from "./utils/prettyByte.ts";
 import { ExtensionCodec, ExtensionCodecType } from "./ExtensionCodec.ts";
 import { getInt64, getUint64 } from "./utils/int.ts";
 import {
-  utf8DecodeJs,
   TEXT_DECODER_THRESHOLD,
+  utf8DecodeJs,
   utf8DecodeTD,
 } from "./utils/utf8.ts";
 import { createDataView, ensureUint8Array } from "./utils/typedArrays.ts";

--- a/Decoder.ts
+++ b/Decoder.ts
@@ -75,7 +75,9 @@ export class Decoder<ContextType> {
 
   public constructor(
     private readonly extensionCodec: ExtensionCodecType<ContextType> =
+      // deno-lint-ignore no-explicit-any
       ExtensionCodec.defaultCodec as any,
+    // deno-lint-ignore no-explicit-any
     private readonly context: ContextType = undefined as any,
     private readonly maxStrLength = DEFAULT_MAX_LENGTH,
     private readonly maxBinLength = DEFAULT_MAX_LENGTH,

--- a/Decoder.ts
+++ b/Decoder.ts
@@ -92,13 +92,15 @@ export class Decoder<ContextType> {
     this.headByte = HEAD_BYTE_REQUIRED;
   }
 
-  private setBuffer(buffer: ArrayLike<number> | ArrayBuffer): void {
+  private setBuffer(
+    buffer: ArrayLike<number> | ArrayBuffer | BufferSource,
+  ): void {
     this.bytes = ensureUint8Array(buffer);
     this.view = createDataView(this.bytes);
     this.pos = 0;
   }
 
-  private appendBuffer(buffer: ArrayLike<number>) {
+  private appendBuffer(buffer: ArrayLike<number> | BufferSource) {
     // Create a fresh copy of `buffer` while caller might re-use and
     // modify the content of the `buffer`.
     // This cause data pollution issue like #2.
@@ -143,7 +145,7 @@ export class Decoder<ContextType> {
   }
 
   public async decodeAsync(
-    stream: AsyncIterable<ArrayLike<number>>,
+    stream: AsyncIterable<ArrayLike<number> | BufferSource>,
   ): Promise<unknown> {
     let decoded = false;
     let object: unknown;

--- a/Encoder.ts
+++ b/Encoder.ts
@@ -1,7 +1,7 @@
 import {
-  utf8EncodeJs,
-  utf8Count,
   TEXT_ENCODER_THRESHOLD,
+  utf8Count,
+  utf8EncodeJs,
   utf8EncodeTE,
 } from "./utils/utf8.ts";
 import { ExtensionCodec, ExtensionCodecType } from "./ExtensionCodec.ts";
@@ -177,7 +177,7 @@ export class Encoder<ContextType> {
     const maxHeaderSize = 1 + 4;
     const strLength = object.length;
 
-    if ( strLength > TEXT_ENCODER_THRESHOLD) {
+    if (strLength > TEXT_ENCODER_THRESHOLD) {
       const byteLength = utf8Count(object);
       this.ensureBufferSizeToWrite(maxHeaderSize + byteLength);
       this.writeStringHeader(byteLength);

--- a/Encoder.ts
+++ b/Encoder.ts
@@ -24,12 +24,12 @@ export class Encoder<ContextType> {
     // deno-lint-ignore no-explicit-any
     private readonly context: ContextType = undefined as any,
     private readonly maxDepth = DEFAULT_MAX_DEPTH,
-    initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
+    private readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
     private readonly sortKeys = false,
     private readonly forceFloat32 = false,
     private readonly ignoreUndefined = false,
   ) {
-    this.view = new DataView(new ArrayBuffer(initialBufferSize));
+    this.view = new DataView(new ArrayBuffer(this.initialBufferSize));
     this.bytes = new Uint8Array(this.view.buffer);
   }
 

--- a/Encoder.ts
+++ b/Encoder.ts
@@ -19,7 +19,9 @@ export class Encoder<ContextType> {
 
   public constructor(
     private readonly extensionCodec: ExtensionCodecType<ContextType> =
+      // deno-lint-ignore no-explicit-any
       ExtensionCodec.defaultCodec as any,
+    // deno-lint-ignore no-explicit-any
     private readonly context: ContextType = undefined as any,
     private readonly maxDepth = DEFAULT_MAX_DEPTH,
     private readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,

--- a/Encoder.ts
+++ b/Encoder.ts
@@ -24,12 +24,12 @@ export class Encoder<ContextType> {
     // deno-lint-ignore no-explicit-any
     private readonly context: ContextType = undefined as any,
     private readonly maxDepth = DEFAULT_MAX_DEPTH,
-    private readonly initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
+    initialBufferSize = DEFAULT_INITIAL_BUFFER_SIZE,
     private readonly sortKeys = false,
     private readonly forceFloat32 = false,
     private readonly ignoreUndefined = false,
   ) {
-    this.view = new DataView(new ArrayBuffer(this.initialBufferSize));
+    this.view = new DataView(new ArrayBuffer(initialBufferSize));
     this.bytes = new Uint8Array(this.view.buffer);
   }
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # msgpack-deno
+
 [![deno doc](https://doc.deno.land/badge.svg)](https://doc.deno.land/https/deno.land/x/msgpack@v1.2/mod.ts)
 
-[msgpack-javascript](https://github.com/msgpack/msgpack-javascript) ported to Deno.
+[msgpack-javascript](https://github.com/msgpack/msgpack-javascript) ported to
+Deno.
 
 ## Example
 
 ```typescript
-import { encode, decode } from 'https://deno.land/x/msgpack@v1.2/mod.ts';
+import { decode, encode } from "https://deno.land/x/msgpack@v1.2/mod.ts";
 
 const object = {
   nil: null,
@@ -20,12 +22,11 @@ const object = {
 };
 
 const encoded: Uint8Array = encode(object);
-console.log(decode(encoded))
-
+console.log(decode(encoded));
 ```
 
-
 This includes code from msgpack-javascript used under the following license:
+
 ```
 Copyright 2019 The MessagePack community.
 
@@ -33,6 +34,3 @@ This software uses the ISC license:
 
 https://opensource.org/licenses/ISC
 ```
-
-
-

--- a/context.ts
+++ b/context.ts
@@ -3,7 +3,8 @@
 export type SplitTypes<T, U> = U extends T ? U : Exclude<T, U>;
 export type SplitUndefined<T> = SplitTypes<T, undefined>;
 
-export type ContextOf<ContextType> = ContextType extends undefined ? {}
+export type ContextOf<ContextType> = ContextType extends undefined
+  ? Record<string, unknown>
   : {
     /**
        * Custom user-defined data, read/writable

--- a/decode.ts
+++ b/decode.ts
@@ -46,10 +46,12 @@ export const defaultDecodeOptions: DecodeOptions = {};
 export function decode<ContextType>(
   buffer: ArrayLike<number> | ArrayBuffer,
   options: DecodeOptions<SplitUndefined<ContextType>> =
+    // deno-lint-ignore no-explicit-any
     defaultDecodeOptions as any,
 ): unknown {
   const decoder = new Decoder<ContextType>(
     options.extensionCodec,
+    // deno-lint-ignore no-explicit-any
     (options as typeof options & { context: any }).context,
     options.maxStrLength,
     options.maxBinLength,

--- a/decodeAsync.ts
+++ b/decodeAsync.ts
@@ -3,15 +3,17 @@ import { DecodeOptions, defaultDecodeOptions } from "./decode.ts";
 import { ensureAsyncIterabe, ReadableStreamLike } from "./utils/stream.ts";
 import { SplitUndefined } from "./context.ts";
 
-export async function decodeAsync<ContextType>(
+export function decodeAsync<ContextType>(
   streamLike: ReadableStreamLike<ArrayLike<number>>,
   options: DecodeOptions<SplitUndefined<ContextType>> =
+    // deno-lint-ignore no-explicit-any
     defaultDecodeOptions as any,
 ): Promise<unknown> {
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
     options.extensionCodec,
+    // deno-lint-ignore no-explicit-any
     (options as typeof options & { context: any }).context,
     options.maxStrLength,
     options.maxBinLength,
@@ -25,12 +27,14 @@ export async function decodeAsync<ContextType>(
 export function decodeArrayStream<ContextType>(
   streamLike: ReadableStreamLike<ArrayLike<number>>,
   options: DecodeOptions<SplitUndefined<ContextType>> =
+    // deno-lint-ignore no-explicit-any
     defaultDecodeOptions as any,
 ) {
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
     options.extensionCodec,
+    // deno-lint-ignore no-explicit-any
     (options as typeof options & { context: any }).context,
     options.maxStrLength,
     options.maxBinLength,
@@ -45,12 +49,14 @@ export function decodeArrayStream<ContextType>(
 export function decodeStream<ContextType>(
   streamLike: ReadableStreamLike<ArrayLike<number>>,
   options: DecodeOptions<SplitUndefined<ContextType>> =
+    // deno-lint-ignore no-explicit-any
     defaultDecodeOptions as any,
 ) {
   const stream = ensureAsyncIterabe(streamLike);
 
   const decoder = new Decoder<ContextType>(
     options.extensionCodec,
+    // deno-lint-ignore no-explicit-any
     (options as typeof options & { context: any }).context,
     options.maxStrLength,
     options.maxBinLength,

--- a/decodeAsync.ts
+++ b/decodeAsync.ts
@@ -4,7 +4,9 @@ import { ensureAsyncIterabe, ReadableStreamLike } from "./utils/stream.ts";
 import { SplitUndefined } from "./context.ts";
 
 export function decodeAsync<ContextType>(
-  streamLike: ReadableStreamLike<ArrayLike<number>>,
+  streamLike:
+    | ReadableStreamLike<ArrayLike<number>>
+    | AsyncGenerator<ArrayLike<number> | BufferSource, void, unknown>,
   options: DecodeOptions<SplitUndefined<ContextType>> =
     // deno-lint-ignore no-explicit-any
     defaultDecodeOptions as any,

--- a/decodeAsync.ts
+++ b/decodeAsync.ts
@@ -1,5 +1,5 @@
 import { Decoder } from "./Decoder.ts";
-import { defaultDecodeOptions, DecodeOptions } from "./decode.ts";
+import { DecodeOptions, defaultDecodeOptions } from "./decode.ts";
 import { ensureAsyncIterabe, ReadableStreamLike } from "./utils/stream.ts";
 import { SplitUndefined } from "./context.ts";
 

--- a/encode.ts
+++ b/encode.ts
@@ -39,10 +39,12 @@ const defaultEncodeOptions: EncodeOptions = {};
 export function encode<ContextType>(
   value: unknown,
   options: EncodeOptions<SplitUndefined<ContextType>> =
+    // deno-lint-ignore no-explicit-any
     defaultEncodeOptions as any,
 ): Uint8Array {
   const encoder = new Encoder<ContextType>(
     options.extensionCodec,
+    // deno-lint-ignore no-explicit-any
     (options as typeof options & { context: any }).context,
     options.maxDepth,
     options.initialBufferSize,

--- a/mod.ts
+++ b/mod.ts
@@ -1,10 +1,10 @@
 // Main Functions:
 
 export { encode } from "./encode.ts";
-export type  { EncodeOptions } from "./encode.ts";
+export type { EncodeOptions } from "./encode.ts";
 export { decode } from "./decode.ts";
-export type  { DecodeOptions } from "./decode.ts";
-export { decodeAsync, decodeArrayStream, decodeStream } from "./decodeAsync.ts";
+export type { DecodeOptions } from "./decode.ts";
+export { decodeArrayStream, decodeAsync, decodeStream } from "./decodeAsync.ts";
 
 /**
  * @experimental `Decoder` is exported for experimental use.
@@ -26,10 +26,10 @@ export type {
 } from "./ExtensionCodec.ts";
 export type { ExtData } from "./ExtData.ts";
 export type {
-  EXT_TIMESTAMP,
+  decodeTimestampExtension,
+  decodeTimestampToTimeSpec,
   encodeDateToTimeSpec,
   encodeTimeSpecToTimestamp,
-  decodeTimestampToTimeSpec,
   encodeTimestampExtension,
-  decodeTimestampExtension,
+  EXT_TIMESTAMP,
 } from "./timestamp.ts";

--- a/mod.ts
+++ b/mod.ts
@@ -24,8 +24,8 @@ export type {
   ExtensionDecoderType,
   ExtensionEncoderType,
 } from "./ExtensionCodec.ts";
-export type { ExtData } from "./ExtData.ts";
-export type {
+export { ExtData } from "./ExtData.ts";
+export {
   decodeTimestampExtension,
   decodeTimestampToTimeSpec,
   encodeDateToTimeSpec,

--- a/tests/CachedKeyDecoder.test.ts
+++ b/tests/CachedKeyDecoder.test.ts
@@ -1,0 +1,76 @@
+import { assert, context, describe, it } from "./deps.ts";
+import { CachedKeyDecoder } from "../CachedKeyDecoder.ts";
+import { utf8Count, utf8EncodeJs } from "../utils/utf8.ts";
+
+function tryDecode(decoder: CachedKeyDecoder, str: string): string {
+  const byteLength = utf8Count(str);
+  const bytes = new Uint8Array(byteLength);
+  utf8EncodeJs(str, bytes, 0);
+  if (!decoder.canBeCached(byteLength)) {
+    throw new Error("Unexpected precondition");
+  }
+  return decoder.decode(bytes, 0, byteLength);
+}
+
+describe("CachedKeyDecoder", () => {
+  context("basic behavior", () => {
+    it("decodes a string", () => {
+      const decoder = new CachedKeyDecoder();
+
+      assert.deepStrictEqual(tryDecode(decoder, "foo"), "foo");
+      assert.deepStrictEqual(tryDecode(decoder, "foo"), "foo");
+      assert.deepStrictEqual(tryDecode(decoder, "foo"), "foo");
+
+      // console.dir(decoder, { depth: 100 });
+    });
+
+    it("decodes strings", () => {
+      const decoder = new CachedKeyDecoder();
+
+      assert.deepStrictEqual(tryDecode(decoder, "foo"), "foo");
+      assert.deepStrictEqual(tryDecode(decoder, "bar"), "bar");
+      assert.deepStrictEqual(tryDecode(decoder, "foo"), "foo");
+
+      // console.dir(decoder, { depth: 100 });
+    });
+
+    it("decodes strings with purging records", () => {
+      const decoder = new CachedKeyDecoder(16, 4);
+
+      for (let i = 0; i < 100; i++) {
+        assert.deepStrictEqual(tryDecode(decoder, "foo1"), "foo1");
+        assert.deepStrictEqual(tryDecode(decoder, "foo2"), "foo2");
+        assert.deepStrictEqual(tryDecode(decoder, "foo3"), "foo3");
+        assert.deepStrictEqual(tryDecode(decoder, "foo4"), "foo4");
+        assert.deepStrictEqual(tryDecode(decoder, "foo5"), "foo5");
+      }
+
+      // console.dir(decoder, { depth: 100 });
+    });
+  });
+
+  context("edge cases", () => {
+    // len=0 is not supported because it is just an empty string
+    it("decodes str with len=1", () => {
+      const decoder = new CachedKeyDecoder();
+
+      assert.deepStrictEqual(tryDecode(decoder, "f"), "f");
+      assert.deepStrictEqual(tryDecode(decoder, "a"), "a");
+      assert.deepStrictEqual(tryDecode(decoder, "f"), "f");
+      assert.deepStrictEqual(tryDecode(decoder, "a"), "a");
+
+      // console.dir(decoder, { depth: 100 });
+    });
+
+    it("decodes str with len=maxKeyLength", () => {
+      const decoder = new CachedKeyDecoder(1);
+
+      assert.deepStrictEqual(tryDecode(decoder, "f"), "f");
+      assert.deepStrictEqual(tryDecode(decoder, "a"), "a");
+      assert.deepStrictEqual(tryDecode(decoder, "f"), "f");
+      assert.deepStrictEqual(tryDecode(decoder, "a"), "a");
+
+      //console.dir(decoder, { depth: 100 });
+    });
+  });
+});

--- a/tests/ExtensionCodec.test.ts
+++ b/tests/ExtensionCodec.test.ts
@@ -1,0 +1,214 @@
+import { assert, context, describe, it, util } from "./deps.ts";
+import { decode, decodeAsync, encode, ExtensionCodec } from "../mod.ts";
+
+describe("ExtensionCodec", () => {
+  context("timestamp", () => {
+    const extensionCodec = ExtensionCodec.defaultCodec;
+
+    it("encodes and decodes a date without milliseconds (timestamp 32)", () => {
+      const date = new Date(1556633024000);
+      const encoded = encode(date, { extensionCodec });
+      assert.deepStrictEqual(
+        decode(encoded, { extensionCodec }),
+        date,
+        `date: ${date.toISOString()}, encoded: ${util.inspect(encoded)}`,
+      );
+    });
+
+    it("encodes and decodes a date with milliseconds (timestamp 64)", () => {
+      const date = new Date(1556633024123);
+      const encoded = encode(date, { extensionCodec });
+      assert.deepStrictEqual(
+        decode(encoded, { extensionCodec }),
+        date,
+        `date: ${date.toISOString()}, encoded: ${util.inspect(encoded)}`,
+      );
+    });
+
+    it("encodes and decodes a future date (timestamp 96)", () => {
+      const date = new Date(0x400000000 * 1000);
+      const encoded = encode(date, { extensionCodec });
+      assert.deepStrictEqual(
+        decode(encoded, { extensionCodec }),
+        date,
+        `date: ${date.toISOString()}, encoded: ${util.inspect(encoded)}`,
+      );
+    });
+  });
+
+  context("custom extensions", () => {
+    const extensionCodec = new ExtensionCodec();
+
+    // Set<T>
+    extensionCodec.register({
+      type: 0,
+      encode: (object: unknown): Uint8Array | null => {
+        if (object instanceof Set) {
+          return encode([...object]);
+        } else {
+          return null;
+        }
+      },
+      decode: (data: Uint8Array) => {
+        const array = decode(data) as Array<unknown>;
+        return new Set(array);
+      },
+    });
+
+    // Map<T>
+    extensionCodec.register({
+      type: 1,
+      encode: (object: unknown): Uint8Array | null => {
+        if (object instanceof Map) {
+          return encode([...object]);
+        } else {
+          return null;
+        }
+      },
+      decode: (data: Uint8Array) => {
+        const array = decode(data) as Array<[unknown, unknown]>;
+        return new Map(array);
+      },
+    });
+
+    it("encodes and decodes custom data types (synchronously)", () => {
+      const set = new Set([1, 2, 3]);
+      const map = new Map([
+        ["foo", "bar"],
+        ["bar", "baz"],
+      ]);
+      const encoded = encode([set, map], { extensionCodec });
+      assert.deepStrictEqual(decode(encoded, { extensionCodec }), [set, map]);
+    });
+
+    it("encodes and decodes custom data types (asynchronously)", async () => {
+      const set = new Set([1, 2, 3]);
+      const map = new Map([
+        ["foo", "bar"],
+        ["bar", "baz"],
+      ]);
+      const encoded = encode([set, map], { extensionCodec });
+      const createStream = async function* () {
+        yield encoded;
+      };
+      assert.deepStrictEqual(
+        await decodeAsync(createStream(), { extensionCodec }),
+        [set, map],
+      );
+    });
+  });
+
+  context("custom extensions with custom context", () => {
+    class Context {
+      // deno-lint-ignore no-explicit-any
+      public expectations: Array<any> = [];
+      constructor(public ctxVal: number) {}
+      // deno-lint-ignore no-explicit-any
+      public hasVisited(val: any) {
+        this.expectations.push(val);
+      }
+    }
+    const extensionCodec = new ExtensionCodec<Context>();
+
+    class Magic<T> {
+      constructor(public val: T) {}
+    }
+
+    // Magic
+    extensionCodec.register({
+      type: 0,
+      encode: (object: unknown, context): Uint8Array | null => {
+        if (object instanceof Magic) {
+          context.hasVisited({ encoding: object.val });
+          return encode({ magic: object.val, ctx: context.ctxVal }, {
+            extensionCodec,
+            context,
+          });
+        } else {
+          return null;
+        }
+      },
+      decode: (data: Uint8Array, extType, context) => {
+        extType;
+        const decoded = decode(data, { extensionCodec, context }) as {
+          magic: number;
+        };
+        context.hasVisited({ decoding: decoded.magic, ctx: context.ctxVal });
+        return new Magic(decoded.magic);
+      },
+    });
+
+    it("encodes and decodes custom data types (synchronously)", () => {
+      const context = new Context(42);
+      const magic1 = new Magic(17);
+      const magic2 = new Magic({ foo: new Magic("inner") });
+      const test = [magic1, magic2];
+      const encoded = encode(test, { extensionCodec, context });
+      assert.deepStrictEqual(
+        decode(encoded, { extensionCodec, context }),
+        test,
+      );
+      assert.deepStrictEqual(context.expectations, [
+        {
+          encoding: magic1.val,
+        },
+        {
+          encoding: magic2.val,
+        },
+        {
+          encoding: magic2.val.foo.val,
+        },
+        {
+          ctx: 42,
+          decoding: magic1.val,
+        },
+        {
+          ctx: 42,
+          decoding: magic2.val.foo.val,
+        },
+        {
+          ctx: 42,
+          decoding: magic2.val,
+        },
+      ]);
+    });
+
+    it("encodes and decodes custom data types (asynchronously)", async () => {
+      const context = new Context(42);
+      const magic1 = new Magic(17);
+      const magic2 = new Magic({ foo: new Magic("inner") });
+      const test = [magic1, magic2];
+      const encoded = encode(test, { extensionCodec, context });
+      const createStream = async function* () {
+        yield encoded;
+      };
+      assert.deepStrictEqual(
+        await decodeAsync(createStream(), { extensionCodec, context }),
+        test,
+      );
+      assert.deepStrictEqual(context.expectations, [
+        {
+          encoding: magic1.val,
+        },
+        {
+          encoding: magic2.val,
+        },
+        {
+          encoding: magic2.val.foo.val,
+        },
+        {
+          ctx: 42,
+          decoding: magic1.val,
+        },
+        {
+          ctx: 42,
+          decoding: magic2.val.foo.val,
+        },
+        {
+          ctx: 42,
+          decoding: magic2.val,
+        },
+      ]);
+    });
+  });
+});

--- a/tests/codec-bigint.test.ts
+++ b/tests/codec-bigint.test.ts
@@ -1,0 +1,43 @@
+import { assert, describe, it } from "./deps.ts";
+import { decode, encode, ExtensionCodec } from "../mod.ts";
+
+const extensionCodec = new ExtensionCodec();
+extensionCodec.register({
+  type: 0,
+  encode: (input: unknown) => {
+    if (typeof input === "bigint") {
+      if (
+        input <= Number.MAX_SAFE_INTEGER && input >= Number.MIN_SAFE_INTEGER
+      ) {
+        return encode(parseInt(input.toString(), 10));
+      } else {
+        return encode(input.toString());
+      }
+    } else {
+      return null;
+    }
+  },
+  decode: (data: Uint8Array) => {
+    return BigInt(decode(data));
+  },
+});
+
+describe("codec BigInt", () => {
+  it("encodes and decodes 0n", () => {
+    const value = BigInt(0);
+    const encoded = encode(value, { extensionCodec });
+    assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+  });
+
+  it("encodes and decodes MAX_SAFE_INTEGER+1", () => {
+    const value = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1);
+    const encoded = encode(value, { extensionCodec });
+    assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+  });
+
+  it("encodes and decodes MIN_SAFE_INTEGER-1", () => {
+    const value = BigInt(Number.MIN_SAFE_INTEGER) - BigInt(1);
+    const encoded = encode(value, { extensionCodec });
+    assert.deepStrictEqual(decode(encoded, { extensionCodec }), value);
+  });
+});

--- a/tests/codec-float.test.ts
+++ b/tests/codec-float.test.ts
@@ -1,0 +1,107 @@
+import { assert, context, describe, ieee754, it } from "./deps.ts";
+import { decode } from "../mod.ts";
+
+const FLOAT32_TYPE = 0xca;
+const FLOAT64_TYPE = 0xcb;
+
+const SPECS = {
+  POSITIVE_ZERO: +0.0,
+  NEGATIVE_ZERO: -0.0,
+  POSITIVE_INFINITY: Number.POSITIVE_INFINITY,
+  NEGATIVE_INFINITY: Number.NEGATIVE_INFINITY,
+
+  POSITIVE_VALUE_1: +0.1,
+  POSITIVE_VALUE_2: +42,
+  POSITIVE_VALUE_3: +Math.PI,
+  POSITIVE_VALUE_4: +Math.E,
+  NEGATIVE_VALUE_1: -0.1,
+  NEGATIVE_VALUE_2: -42,
+  NEGATIVE_VALUE_3: -Math.PI,
+  NEGATIVE_VALUE_4: -Math.E,
+
+  MAX_SAFE_INTEGER: Number.MAX_SAFE_INTEGER,
+  MIN_SAFE_INTEGER: Number.MIN_SAFE_INTEGER,
+
+  MAX_VALUE: Number.MAX_VALUE,
+  MIN_VALUE: Number.MIN_VALUE,
+} as Record<string, number>;
+
+describe("codec: float 32/64", () => {
+  context("float 32", () => {
+    for (const name of Object.keys(SPECS)) {
+      const value = SPECS[name];
+
+      it(`decodes ${name} (${value})`, () => {
+        const buf: Array<number> = [];
+        // deno-lint-ignore no-explicit-any
+        ieee754.write(buf as any, value, 0, false, 23, 4);
+        // deno-lint-ignore no-explicit-any
+        const expected = ieee754.read(buf as any, 0, false, 23, 4);
+
+        assert.deepStrictEqual(
+          decode([FLOAT32_TYPE, ...buf]),
+          expected,
+          "matched sign",
+        );
+        assert.notDeepStrictEqual(
+          decode([FLOAT32_TYPE, ...buf]),
+          -expected,
+          "unmatched sign",
+        );
+      });
+    }
+
+    it(`decodes NaN`, () => {
+      const buf: Array<number> = [];
+      // deno-lint-ignore no-explicit-any
+      ieee754.write(buf as any, NaN, 0, false, 23, 4);
+      // deno-lint-ignore no-explicit-any
+      const expected = ieee754.read(buf as any, 0, false, 23, 4);
+
+      assert.deepStrictEqual(
+        decode([FLOAT32_TYPE, ...buf]),
+        expected,
+        "matched sign",
+      );
+    });
+  });
+
+  context("float 64", () => {
+    for (const name of Object.keys(SPECS)) {
+      const value = SPECS[name];
+
+      it(`decodes ${name} (${value})`, () => {
+        const buf: Array<number> = [];
+        // deno-lint-ignore no-explicit-any
+        ieee754.write(buf as any, value, 0, false, 52, 8);
+        // deno-lint-ignore no-explicit-any
+        const expected = ieee754.read(buf as any, 0, false, 52, 8);
+
+        assert.deepStrictEqual(
+          decode([FLOAT64_TYPE, ...buf]),
+          expected,
+          "matched sign",
+        );
+        assert.notDeepStrictEqual(
+          decode([FLOAT64_TYPE, ...buf]),
+          -expected,
+          "unmatched sign",
+        );
+      });
+    }
+
+    it(`decodes NaN`, () => {
+      const buf: Array<number> = [];
+      // deno-lint-ignore no-explicit-any
+      ieee754.write(buf as any, NaN, 0, false, 52, 8);
+      // deno-lint-ignore no-explicit-any
+      const expected = ieee754.read(buf as any, 0, false, 52, 8);
+
+      assert.deepStrictEqual(
+        decode([FLOAT64_TYPE, ...buf]),
+        expected,
+        "matched sign",
+      );
+    });
+  });
+});

--- a/tests/codec-int.test.ts
+++ b/tests/codec-int.test.ts
@@ -1,0 +1,45 @@
+import { assert, context, describe, it } from "./deps.ts";
+import { getInt64, getUint64, setInt64, setUint64 } from "../utils/int.ts";
+
+const INT64SPECS = {
+  ZERO: 0,
+  ONE: 1,
+  MINUS_ONE: -1,
+  X_FF: 0xff,
+  MINUS_X_FF: -0xff,
+  INT32_MAX: 0x7fffffff,
+  INT32_MIN: -0x7fffffff - 1,
+  MAX_SAFE_INTEGER: Number.MAX_SAFE_INTEGER,
+  MIN_SAFE_INTEGER: Number.MIN_SAFE_INTEGER,
+} as Record<string, number>;
+
+describe("codec: int64 / uint64", () => {
+  context("int 64", () => {
+    for (const name of Object.keys(INT64SPECS)) {
+      const value = INT64SPECS[name]!;
+
+      it(`sets and gets ${value} (${value < 0 ? "-" : ""}0x${Math.abs(value).toString(16)})`, () => {
+        const b = new Uint8Array(8);
+        const view = new DataView(b.buffer);
+        setInt64(view, 0, value);
+        assert.deepStrictEqual(getInt64(view, 0), value);
+      });
+    }
+  });
+
+  context("uint 64", () => {
+    it(`sets and gets 0`, () => {
+      const b = new Uint8Array(8);
+      const view = new DataView(b.buffer);
+      setUint64(view, 0, 0);
+      assert.deepStrictEqual(getUint64(view, 0), 0);
+    });
+
+    it(`sets and gets MAX_SAFE_INTEGER`, () => {
+      const b = new Uint8Array(8);
+      const view = new DataView(b.buffer);
+      setUint64(view, 0, Number.MAX_SAFE_INTEGER);
+      assert.deepStrictEqual(getUint64(view, 0), Number.MAX_SAFE_INTEGER);
+    });
+  });
+});

--- a/tests/codec-timestamp.test.ts
+++ b/tests/codec-timestamp.test.ts
@@ -1,0 +1,72 @@
+import { assert, buffer, context, describe, it, util } from "./deps.ts";
+import {
+  decode,
+  decodeTimestampExtension,
+  decodeTimestampToTimeSpec,
+  encode,
+  encodeDateToTimeSpec,
+  encodeTimestampExtension,
+} from "../mod.ts";
+
+const Buffer = buffer.Buffer;
+const TIME = 1556636810389;
+
+const SPECS = {
+  ZERO: new Date(0),
+  TIME_BEFORE_EPOCH_NS: new Date(-1),
+  TIME_BEFORE_EPOCH_SEC: new Date(-1000),
+  TIME_BEFORE_EPOCH_SEC_AND_NS: new Date(-1002),
+  TIMESTAMP32: new Date(Math.floor(TIME / 1000) * 1000),
+  TIMESTAMP64: new Date(TIME),
+  TIMESTAMP64_OVER_INT32: new Date(Date.UTC(2200, 0)), // cf. https://github.com/msgpack/msgpack-ruby/pull/172
+  TIMESTAMP96_SEC_OVER_UINT32: new Date(0x400000000 * 1000),
+  TIMESTAMP96_SEC_OVER_UINT32_WITH_NS: new Date(0x400000000 * 1000 + 2),
+
+  REGRESSION_1: new Date(1556799054803),
+} as Record<string, Date>;
+
+describe("codec: timestamp 32/64/96", () => {
+  context("encode / decode", () => {
+    for (const name of Object.keys(SPECS)) {
+      const value = SPECS[name]!;
+
+      it(`encodes and decodes ${name} (${value.toISOString()})`, () => {
+        const encoded = encode(value);
+        assert.deepStrictEqual(
+          decode(encoded),
+          value,
+          `encoded: ${util.inspect(Buffer.from(encoded))}`,
+        );
+      });
+    }
+  });
+
+  context("encodeDateToTimeSpec", () => {
+    it("normalizes new Date(-1) to { sec: -1, nsec: 999000000 }", () => {
+      assert.deepStrictEqual(encodeDateToTimeSpec(new Date(-1)), {
+        sec: -1,
+        nsec: 999000000,
+      });
+    });
+  });
+
+  context("encodeDateToTimeSpec", () => {
+    it("decodes timestamp-ext binary to TimeSpec", () => {
+      const encoded = encodeTimestampExtension(new Date(42000))!;
+      assert.deepStrictEqual(decodeTimestampToTimeSpec(encoded), {
+        sec: 42,
+        nsec: 0,
+      });
+    });
+  });
+
+  context("decodeTimestampExtension", () => {
+    context("for broken data", () => {
+      it("throws errors", () => {
+        assert.throws(() => {
+          decodeTimestampExtension(Uint8Array.from([0]));
+        }, /unrecognized data size for timestamp/i);
+      });
+    });
+  });
+});

--- a/tests/decode-blob.test.ts
+++ b/tests/decode-blob.test.ts
@@ -1,0 +1,14 @@
+import { assert, describe, it } from "./deps.ts";
+import { decode, decodeAsync, encode } from "../mod.ts";
+
+describe("Blob", () => {
+  it("decodes it with `decode()`", async function () {
+    const blob = new Blob([encode("Hello!")]);
+    assert.deepStrictEqual(decode(await blob.arrayBuffer()), "Hello!");
+  });
+
+  it("decodes it with `decodeAsync()`", async function () {
+    const blob = new Blob([encode("Hello!")]);
+    assert.deepStrictEqual(await decodeAsync(blob.stream()), "Hello!");
+  });
+});

--- a/tests/decode-max-length.test.ts
+++ b/tests/decode-max-length.test.ts
@@ -1,0 +1,95 @@
+import { assert, assertRejects, context, describe, it } from "./deps.ts";
+import { decode, decodeAsync, encode } from "../mod.ts";
+import type { DecodeOptions } from "../decode.ts";
+
+describe("decode with max${Type}Length specified", () => {
+  async function* createStream<T>(input: T) {
+    yield input;
+  }
+
+  context("maxStrLength", () => {
+    const input = encode("foo");
+    const options: DecodeOptions = { maxStrLength: 1 };
+
+    it("throws errors (synchronous)", () => {
+      assert.throws(() => {
+        decode(input, options);
+      }, /max length exceeded/i);
+    });
+
+    it("throws errors (asynchronous)", async () => {
+      await assertRejects(async () => {
+        await decodeAsync(createStream(input), options);
+      }, /max length exceeded/i);
+    });
+  });
+
+  context("maxBinLength", () => {
+    const input = encode(Uint8Array.from([1, 2, 3]));
+    const options: DecodeOptions = { maxBinLength: 1 };
+
+    it("throws errors (synchronous)", () => {
+      assert.throws(() => {
+        decode(input, options);
+      }, /max length exceeded/i);
+    });
+
+    it("throws errors (asynchronous)", async () => {
+      await assertRejects(async () => {
+        await decodeAsync(createStream(input), options);
+      }, /max length exceeded/i);
+    });
+  });
+
+  context("maxArrayLength", () => {
+    const input = encode([1, 2, 3]);
+    const options: DecodeOptions = { maxArrayLength: 1 };
+
+    it("throws errors (synchronous)", () => {
+      assert.throws(() => {
+        decode(input, options);
+      }, /max length exceeded/i);
+    });
+
+    it("throws errors (asynchronous)", async () => {
+      await assertRejects(async () => {
+        await decodeAsync(createStream(input), options);
+      }, /max length exceeded/i);
+    });
+  });
+
+  context("maxMapLength", () => {
+    const input = encode({ foo: 1, bar: 1, baz: 3 });
+    const options: DecodeOptions = { maxMapLength: 1 };
+
+    it("throws errors (synchronous)", () => {
+      assert.throws(() => {
+        decode(input, options);
+      }, /max length exceeded/i);
+    });
+
+    it("throws errors (asynchronous)", async () => {
+      await assertRejects(async () => {
+        await decodeAsync(createStream(input), options);
+      }, /max length exceeded/i);
+    });
+  });
+
+  context("maxExtType", () => {
+    const input = encode(new Date());
+    // timextamp ext requires at least 4 bytes.
+    const options: DecodeOptions = { maxExtLength: 1 };
+
+    it("throws errors (synchronous)", () => {
+      assert.throws(() => {
+        decode(input, options);
+      }, /max length exceeded/i);
+    });
+
+    it("throws errors (asynchronous)", async () => {
+      await assertRejects(async () => {
+        await decodeAsync(createStream(input), options);
+      }, /max length exceeded/i);
+    });
+  });
+});

--- a/tests/decodeArrayStream.test.ts
+++ b/tests/decodeArrayStream.test.ts
@@ -1,0 +1,93 @@
+import { assert, assertRejects, describe, it } from "./deps.ts";
+import { decodeArrayStream, encode } from "../mod.ts";
+
+describe("decodeArrayStream", () => {
+  const generateSampleObject = () => {
+    return {
+      id: Math.random(),
+      name: "test",
+    };
+  };
+
+  // deno-lint-ignore no-explicit-any
+  const createStream = async function* (object: any) {
+    for (const byte of encode(object)) {
+      yield [byte];
+    }
+  };
+
+  it("decodes numbers array (array8)", async () => {
+    const object = [1, 2, 3, 4, 5];
+
+    const result: Array<unknown> = [];
+
+    for await (const item of decodeArrayStream(createStream(object))) {
+      result.push(item);
+    }
+
+    assert.deepStrictEqual(object, result);
+  });
+
+  it("decodes numbers of array (array16)", async () => {
+    const createStream = async function* () {
+      yield [0xdc, 0, 3];
+      yield encode(1);
+      yield encode(2);
+      yield encode(3);
+    };
+
+    const result: Array<unknown> = [];
+
+    for await (const item of decodeArrayStream(createStream())) {
+      result.push(item);
+    }
+
+    assert.deepStrictEqual(result, [1, 2, 3]);
+  });
+
+  it("decodes numbers of array (array32)", async () => {
+    const createStream = async function* () {
+      yield [0xdd, 0, 0, 0, 3];
+      yield encode(1);
+      yield encode(2);
+      yield encode(3);
+    };
+
+    const result: Array<unknown> = [];
+
+    for await (const item of decodeArrayStream(createStream())) {
+      result.push(item);
+    }
+
+    assert.deepStrictEqual(result, [1, 2, 3]);
+  });
+
+  it("decodes objects array", async () => {
+    // deno-lint-ignore no-explicit-any
+    const objectsArrays: Array<any> = [];
+
+    for (let i = 0; i < 10; i++) {
+      objectsArrays.push(generateSampleObject());
+    }
+
+    const result: Array<unknown> = [];
+
+    for await (const item of decodeArrayStream(createStream(objectsArrays))) {
+      result.push(item);
+    }
+
+    assert.deepStrictEqual(objectsArrays, result);
+  });
+
+  it("fails for non array input", async () => {
+    const object = "demo";
+
+    await assertRejects(async () => {
+      const result: Array<unknown> = [];
+
+      for await (const item of decodeArrayStream(createStream(object))) {
+        result.push(item);
+      }
+    }, /.*Unrecognized array type byte:.*/i);
+  });
+});

--- a/tests/decodeAsync.test.ts
+++ b/tests/decodeAsync.test.ts
@@ -1,0 +1,123 @@
+import { assert, describe, it } from "./deps.ts";
+import { decodeAsync, encode } from "../mod.ts";
+
+describe("decodeAsync", () => {
+  function wrapWithNoisyBuffer(byte: number) {
+    return Uint8Array.from([0x01, byte, 0x02]).subarray(1, 2);
+  }
+
+  it("decodes nil", async () => {
+    const createStream = async function* () {
+      yield wrapWithNoisyBuffer(0xc0); // nil
+    };
+
+    const object = await decodeAsync(createStream());
+    assert.deepStrictEqual(object, null);
+  });
+
+  it("decodes fixarray [nil]", async () => {
+    const createStream = async function* () {
+      yield wrapWithNoisyBuffer(0x91); // fixarray size=1
+      yield [0xc0]; // nil
+    };
+
+    const object = await decodeAsync(createStream());
+    assert.deepStrictEqual(object, [null]);
+  });
+
+  it("decodes fixmap {'foo': 'bar'}", async () => {
+    const createStream = async function* () {
+      yield [0x81]; // fixmap size=1
+      yield encode("foo");
+      yield encode("bar");
+    };
+
+    const object = await decodeAsync(createStream());
+    assert.deepStrictEqual(object, { "foo": "bar" });
+  });
+
+  it("decodes multi-byte integer byte-by-byte", async () => {
+    const createStream = async function* () {
+      yield [0xcd]; // uint 16
+      yield [0x12];
+      yield [0x34];
+    };
+    const object = await decodeAsync(createStream());
+    assert.deepStrictEqual(object, 0x1234);
+  });
+
+  it("decodes fixstr byte-by-byte", async () => {
+    const createStream = async function* () {
+      yield [0xa3]; // fixstr size=3
+      yield [0x66]; // "f"
+      yield [0x6f]; // "o"
+      yield [0x6f]; // "o"
+    };
+    const object = await decodeAsync(createStream());
+    assert.deepStrictEqual(object, "foo");
+  });
+
+  it("decodes binary byte-by-byte", async () => {
+    const createStream = async function* () {
+      yield [0xc4]; // bin 8
+      yield [0x03]; // bin size=3
+      yield [0x66]; // "f"
+      yield [0x6f]; // "o"
+      yield [0x6f]; // "o"
+    };
+    const object = await decodeAsync(createStream());
+    assert.deepStrictEqual(object, Uint8Array.from([0x66, 0x6f, 0x6f]));
+  });
+
+  it("decodes binary with noisy buffer", async () => {
+    const createStream = async function* () {
+      yield wrapWithNoisyBuffer(0xc5); // bin 16
+      yield [0x00];
+      yield [0x00]; // bin size=0
+    };
+    const object = await decodeAsync(createStream());
+    assert.deepStrictEqual(object, new Uint8Array(0));
+  });
+
+  it("decodes mixed object byte-by-byte", async () => {
+    const object = {
+      nil: null,
+      true: true,
+      false: false,
+      int: -42,
+      uint64: Number.MAX_SAFE_INTEGER,
+      int64: Number.MIN_SAFE_INTEGER,
+      float: Math.PI,
+      string: "Hello, world!",
+      longString: "Hello, world!\n".repeat(100),
+      binary: Uint8Array.from([0xf1, 0xf2, 0xf3]),
+      array: [1000, 2000, 3000],
+      map: { foo: 1, bar: 2, baz: 3 },
+      timestampExt: new Date(),
+      map0: {},
+      array0: [],
+      str0: "",
+      bin0: Uint8Array.from([]),
+    };
+
+    const createStream = async function* () {
+      for (const byte of encode(object)) {
+        yield [byte];
+      }
+    };
+    assert.deepStrictEqual(await decodeAsync(createStream()), object);
+  });
+
+  it("decodes BufferSource", async () => {
+    // https://developer.mozilla.org/en-US/docs/Web/API/BufferSource
+    const createStream = async function* () {
+      yield [0x81] as ArrayLike<number>; // fixmap size=1
+      yield encode("foo") as BufferSource;
+      yield encode("bar") as BufferSource;
+    };
+
+    // createStream() returns AsyncGenerator<ArrayLike<number> | BufferSource, ...>
+    const object = await decodeAsync(createStream());
+    assert.deepStrictEqual(object, { "foo": "bar" });
+  });
+});

--- a/tests/decodeStream.test.ts
+++ b/tests/decodeStream.test.ts
@@ -1,0 +1,62 @@
+import { assert, describe, it } from "./deps.ts";
+import { decodeStream, encode } from "../mod.ts";
+
+describe("decodeStream", () => {
+  it("decodes stream", async () => {
+    const items = [
+      "foo",
+      10,
+      {
+        name: "bar",
+      },
+      [1, 2, 3],
+    ];
+
+    const createStream = async function* (): AsyncGenerator<Uint8Array> {
+      for (const item of items) {
+        yield encode(item);
+      }
+    };
+
+    const result: Array<unknown> = [];
+
+    for await (const item of decodeStream(createStream())) {
+      result.push(item);
+    }
+
+    assert.deepStrictEqual(result, items);
+  });
+
+  it("decodes multiple objects in a single binary stream", async () => {
+    const items = [
+      "foo",
+      10,
+      {
+        name: "bar",
+      },
+      [1, 2, 3],
+    ];
+
+    const encodedItems = items.map((item) => encode(item));
+    const encoded = new Uint8Array(
+      encodedItems.reduce((p, c) => p + c.byteLength, 0),
+    );
+    let offset = 0;
+    for (const encodedItem of encodedItems) {
+      encoded.set(encodedItem, offset);
+      offset += encodedItem.byteLength;
+    }
+
+    const createStream = async function* (): AsyncGenerator<Uint8Array> {
+      yield encoded;
+    };
+
+    const result: Array<unknown> = [];
+
+    for await (const item of decodeStream(createStream())) {
+      result.push(item);
+    }
+
+    assert.deepStrictEqual(result, items);
+  });
+});

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,0 +1,2 @@
+export { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
+export * as io from "https://deno.land/std@0.93.0/io/mod.ts";

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,2 +1,45 @@
-export { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
+import * as assert from "https://deno.land/std@0.93.0/node/assert.ts";
+
+export { assertEquals } from "https://deno.land/std@0.93.0/testing/asserts.ts";
+export * as assert from "https://deno.land/std@0.93.0/node/assert.ts";
+export * as util from "https://deno.land/std@0.93.0/node/util.ts";
+export * as buffer from "https://deno.land/std@0.93.0/node/buffer.ts";
 export * as io from "https://deno.land/std@0.93.0/io/mod.ts";
+export * as ieee754 from "https://deno.land/x/ieee754@v1.0.0/mod.ts";
+
+export { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+
+const currentScopes: string[] = [];
+
+export function describe(name: string, fn: () => void): void {
+  currentScopes.push(name);
+  fn();
+  currentScopes.pop();
+}
+
+export function it(name: string, fn: () => void): void {
+  const fullName = [...currentScopes, name].join(" > ");
+  Deno.test(fullName, fn);
+}
+
+export const context = it;
+
+type ThrowsError = Parameters<typeof assert.throws>[1];
+type ThrowsMessage = Parameters<typeof assert.throws>[2];
+export async function assertRejects(
+  asyncFn: () => Promise<void>,
+  error?: ThrowsError,
+  message?: ThrowsMessage,
+): Promise<void> {
+  try {
+    await asyncFn();
+  } catch (e) {
+    assert.throws(
+      () => {
+        throw e;
+      },
+      error,
+      message,
+    );
+  }
+}

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -1,0 +1,112 @@
+import { assert, assertRejects, context, describe, it } from "./deps.ts";
+import { decode, decodeAsync, encode } from "../mod.ts";
+import { DataViewIndexOutOfBoundsError } from "../Decoder.ts";
+
+describe("edge cases", () => {
+  context("try to encode cyclic refs", () => {
+    it("throws errors on arrays", () => {
+      // deno-lint-ignore no-explicit-any
+      const cyclicRefs: Array<any> = [];
+      cyclicRefs.push(cyclicRefs);
+      assert.throws(() => {
+        encode(cyclicRefs);
+      }, /too deep/i);
+    });
+
+    it("throws errors on objects", () => {
+      // deno-lint-ignore no-explicit-any
+      const cyclicRefs: Record<string, any> = {};
+      cyclicRefs["foo"] = cyclicRefs;
+      assert.throws(() => {
+        encode(cyclicRefs);
+      }, /too deep/i);
+    });
+  });
+
+  context("try to encode non-encodable objects", () => {
+    it("throws errors", () => {
+      assert.throws(() => {
+        encode(() => {});
+      }, /unrecognized object/i);
+    });
+  });
+
+  context("try to decode a map with non-string keys (asynchronous)", () => {
+    it("throws errors", async () => {
+      const createStream = async function* () {
+        yield [0x81]; // fixmap size=1
+        yield encode(null);
+        yield encode(null);
+      };
+
+      await assertRejects(async () => {
+        await decodeAsync(createStream());
+      }, /The type of key must be string/i);
+    });
+  });
+
+  context("try to decode invlid MessagePack binary", () => {
+    it("throws errors", () => {
+      const TYPE_NEVER_USED = 0xc1;
+
+      assert.throws(() => {
+        decode([TYPE_NEVER_USED]);
+      }, /unrecognized type byte/i);
+    });
+  });
+
+  context("try to decode insufficient data", () => {
+    it("throws errors (synchronous)", () => {
+      assert.throws(() => {
+        decode([
+          0x92, // fixarray size=2
+          0xc0, // nil
+        ]);
+        // [IE11] A raw error thrown by DataView
+      }, DataViewIndexOutOfBoundsError);
+    });
+
+    it("throws errors (asynchronous)", async () => {
+      const createStream = async function* () {
+        yield [0x92]; // fixarray size=2
+        yield encode(null);
+      };
+
+      await assertRejects(async () => {
+        await decodeAsync(createStream());
+      }, RangeError);
+    });
+  });
+
+  context("try to decode data with extra bytes", () => {
+    it("throws errors (synchronous)", () => {
+      assert.throws(() => {
+        decode([
+          0x90, // fixarray size=0
+          ...encode(null),
+        ]);
+      }, RangeError);
+    });
+
+    it("throws errors (asynchronous)", async () => {
+      const createStream = async function* () {
+        yield [0x90]; // fixarray size=0
+        yield encode(null);
+      };
+
+      await assertRejects(async () => {
+        await decodeAsync(createStream());
+      }, RangeError);
+    });
+
+    it("throws errors (asynchronous)", async () => {
+      const createStream = async function* () {
+        yield [0x90, ...encode(null)]; // fixarray size=0 + nil
+      };
+
+      await assertRejects(async () => {
+        await decodeAsync(createStream());
+      }, RangeError);
+    });
+  });
+});

--- a/tests/encode.test.ts
+++ b/tests/encode.test.ts
@@ -1,0 +1,98 @@
+import { assert, context, describe, it } from "./deps.ts";
+import { decode, encode } from "../mod.ts";
+
+describe("encode", () => {
+  context("sortKeys", () => {
+    it("canonicalizes encoded binaries", () => {
+      assert.deepStrictEqual(
+        encode({ a: 1, b: 2 }, { sortKeys: true }),
+        encode({ b: 2, a: 1 }, { sortKeys: true }),
+      );
+    });
+  });
+
+  context("forceFloat32", () => {
+    it("encodes numbers in float64 wihout forceFloat32", () => {
+      assert.deepStrictEqual(
+        encode(3.14),
+        Uint8Array.from([0xcb, 0x40, 0x9, 0x1e, 0xb8, 0x51, 0xeb, 0x85, 0x1f]),
+      );
+    });
+
+    it("encodes numbers in float32 when forceFloat32=true", () => {
+      assert.deepStrictEqual(
+        encode(3.14, { forceFloat32: true }),
+        Uint8Array.from([0xca, 0x40, 0x48, 0xf5, 0xc3]),
+      );
+    });
+
+    it("encodes numbers in float64 with forceFloat32=false", () => {
+      assert.deepStrictEqual(
+        encode(3.14, { forceFloat32: false }),
+        Uint8Array.from([0xcb, 0x40, 0x9, 0x1e, 0xb8, 0x51, 0xeb, 0x85, 0x1f]),
+      );
+    });
+  });
+
+  context("forceFloat", () => {
+    it("encodes integers as integers without forceIntegerToFloat", () => {
+      assert.deepStrictEqual(encode(3), Uint8Array.from([0x3]));
+    });
+
+    it("encodes integers as floating point when forceIntegerToFloat=true", () => {
+      assert.deepStrictEqual(
+        encode(3, { forceIntegerToFloat: true }),
+        Uint8Array.from([0xcb, 0x40, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+      );
+    });
+
+    it("encodes integers as float32 when forceIntegerToFloat=true and forceFloat32=true", () => {
+      assert.deepStrictEqual(
+        encode(3, { forceIntegerToFloat: true, forceFloat32: true }),
+        Uint8Array.from([0xca, 0x40, 0x40, 0x00, 0x00]),
+      );
+    });
+
+    it("encodes integers as integers when forceIntegerToFloat=false", () => {
+      assert.deepStrictEqual(
+        encode(3, { forceIntegerToFloat: false }),
+        Uint8Array.from([0x3]),
+      );
+    });
+  });
+
+  context("ignoreUndefined", () => {
+    it("encodes { foo: undefined } as is by default", () => {
+      assert.deepStrictEqual(decode(encode({ foo: undefined, bar: 42 })), {
+        foo: null,
+        bar: 42,
+      });
+    });
+
+    it("encodes { foo: undefined } as is with `ignoreUndefined: false`", () => {
+      assert.deepStrictEqual(
+        decode(encode({ foo: undefined, bar: 42 }, { ignoreUndefined: false })),
+        {
+          foo: null,
+          bar: 42,
+        },
+      );
+    });
+
+    it("encodes { foo: undefined } to {} with `ignoreUndefined: true`", () => {
+      assert.deepStrictEqual(
+        decode(encode({ foo: undefined, bar: 42 }, { ignoreUndefined: true })),
+        { bar: 42 },
+      );
+    });
+  });
+
+  context("ArrayBuffer as buffer", () => {
+    const buffer = encode([1, 2, 3]);
+    const arrayBuffer = buffer.buffer.slice(
+      buffer.byteOffset,
+      buffer.byteLength,
+    );
+    assert.deepStrictEqual(decode(arrayBuffer), decode(buffer));
+  });
+});

--- a/tests/msgpack-ext.test.ts
+++ b/tests/msgpack-ext.test.ts
@@ -1,0 +1,33 @@
+import { assert, describe, it } from "./deps.ts";
+import { decode, encode, ExtData } from "../mod.ts";
+
+function seq(n: number) {
+  const a: Array<number> = [];
+  for (let i = 0; i < n; i++) {
+    a.push((i + 1) % 0xff);
+  }
+  return Uint8Array.from(a);
+}
+
+describe("msgpack-ext", () => {
+  const SPECS = {
+    FIXEXT1: [0xd4, new ExtData(0, seq(1))],
+    FIXEXT2: [0xd5, new ExtData(0, seq(2))],
+    FIXEXT4: [0xd6, new ExtData(0, seq(4))],
+    FIXEXT8: [0xd7, new ExtData(0, seq(8))],
+    FIXEXT16: [0xd8, new ExtData(0, seq(16))],
+    EXT8: [0xc7, new ExtData(0, seq(17))],
+    EXT16: [0xc8, new ExtData(0, seq(0x100))],
+    EXT32: [0xc9, new ExtData(0, seq(0x10000))],
+  } as Record<string, [number, ExtData]>;
+
+  for (const name of Object.keys(SPECS)) {
+    const [msgpackType, extData] = SPECS[name]!;
+
+    it(`preserves ExtData by decode(encode(${name}))`, () => {
+      const encoded = encode(extData);
+      assert.strictEqual(encoded[0], msgpackType);
+      assert.deepStrictEqual(decode(encoded), extData);
+    });
+  }
+});

--- a/tests/readme.test.ts
+++ b/tests/readme.test.ts
@@ -1,0 +1,24 @@
+import { assert, context, describe, it } from "./deps.ts";
+import { decode, encode } from "../mod.ts";
+
+describe("README", () => {
+  context("## Synopsis", () => {
+    it("runs", () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded = encode(object);
+      // encoded is an Uint8Array instance
+
+      assert.deepStrictEqual(decode(encoded), object);
+    });
+  });
+});

--- a/tests/reuse-instances.test.ts
+++ b/tests/reuse-instances.test.ts
@@ -1,0 +1,185 @@
+import { assert, context, describe, it } from "./deps.ts";
+import { Decoder, Encoder } from "../mod.ts";
+
+// deno-lint-ignore no-explicit-any
+const createStream = async function* (...args: any) {
+  for (const item of args) {
+    yield item;
+  }
+};
+
+describe("shared instances", () => {
+  context("encode() and decodeSync()", () => {
+    const encoder = new Encoder();
+    const decoder = new Decoder();
+
+    it("runs #1", () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      assert.deepStrictEqual(decoder.decode(encoded), object);
+    });
+
+    it("runs #2", () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      assert.deepStrictEqual(decoder.decode(encoded), object);
+    });
+  });
+
+  context("encode() and decodeAsync()", () => {
+    const encoder = new Encoder();
+    const decoder = new Decoder();
+
+    it("runs #1", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      assert.deepStrictEqual(
+        await decoder.decodeAsync(createStream(encoded)),
+        object,
+      );
+    });
+
+    it("runs #2", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      assert.deepStrictEqual(
+        await decoder.decodeAsync(createStream(encoded)),
+        object,
+      );
+    });
+  });
+
+  context("encode() and decodeStream()", () => {
+    const encoder = new Encoder();
+    const decoder = new Decoder();
+
+    it("runs #1", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      // deno-lint-ignore no-explicit-any
+      const a: Array<any> = [];
+      for await (const item of decoder.decodeStream(createStream(encoded))) {
+        a.push(item);
+      }
+      assert.deepStrictEqual(a, [object]);
+    });
+
+    it("runs #2", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode(object);
+      // deno-lint-ignore no-explicit-any
+      const a: Array<any> = [];
+      for await (const item of decoder.decodeStream(createStream(encoded))) {
+        a.push(item);
+      }
+      assert.deepStrictEqual(a, [object]);
+    });
+  });
+
+  context("encode() and decodeArrayStream()", () => {
+    const encoder = new Encoder();
+    const decoder = new Decoder();
+
+    it("runs #1", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode([object]);
+      // deno-lint-ignore no-explicit-any
+      const a: Array<any> = [];
+      for await (const item of decoder.decodeStream(createStream(encoded))) {
+        a.push(item);
+      }
+      assert.deepStrictEqual(a, [[object]]);
+    });
+
+    it("runs #2", async () => {
+      const object = {
+        nil: null,
+        integer: 1,
+        float: Math.PI,
+        string: "Hello, world!",
+        binary: Uint8Array.from([1, 2, 3]),
+        array: [10, 20, 30],
+        map: { foo: "bar" },
+        timestampExt: new Date(),
+      };
+
+      const encoded: Uint8Array = encoder.encode([object]);
+      // deno-lint-ignore no-explicit-any
+      const a: Array<any> = [];
+      for await (const item of decoder.decodeStream(createStream(encoded))) {
+        a.push(item);
+      }
+      assert.deepStrictEqual(a, [[object]]);
+    });
+  });
+});

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -1,17 +1,18 @@
 import { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
+import * as io from "https://deno.land/std@0.93.0/io/mod.ts";
 
 import { decodeStream, encode } from "../mod.ts";
 
 Deno.test("Test whether decodeStream properly handles complete data", async () => {
-  const reader = new Deno.Buffer(encode("0123456789"));
-  const stream = Deno.iter(reader, { bufSize: 10 });
+  const reader = new io.Buffer(encode("0123456789"));
+  const stream = io.iter(reader, { bufSize: 10 });
   const result = await consumeAll(decodeStream(stream));
   assertEquals(result, ["0123456789"]);
 });
 
 Deno.test("Test whether decodeStream properly handles incomplete data", async () => {
-  const reader = new Deno.Buffer(encode("0123456789"));
-  const stream = Deno.iter(reader, { bufSize: 8 });
+  const reader = new io.Buffer(encode("0123456789"));
+  const stream = io.iter(reader, { bufSize: 8 });
   const result = await consumeAll(decodeStream(stream));
   assertEquals(result, ["0123456789"]);
 });

--- a/tests/stream_test.ts
+++ b/tests/stream_test.ts
@@ -1,6 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
-import * as io from "https://deno.land/std@0.93.0/io/mod.ts";
-
+import { assertEquals, io } from "./deps.ts";
 import { decodeStream, encode } from "../mod.ts";
 
 Deno.test("Test whether decodeStream properly handles complete data", async () => {

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,5 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
-
+import { assertEquals } from "./deps.ts";
 import { decode, encode } from "../mod.ts";
 
 // deno-lint-ignore no-explicit-any

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -1,8 +1,6 @@
-import {
-  assertEquals,
-} from "https://deno.land/std@0.68.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
 
-import { encode, decode } from "../mod.ts";
+import { decode, encode } from "../mod.ts";
 
 function test(obj: any) {
   assertEquals(obj, decode(encode(obj)));

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
 
 import { decode, encode } from "../mod.ts";
 
+// deno-lint-ignore no-explicit-any
 function test(obj: any) {
   assertEquals(obj, decode(encode(obj)));
 }

--- a/tests/whatwg-streams.test.ts
+++ b/tests/whatwg-streams.test.ts
@@ -1,0 +1,48 @@
+import { assert, describe, it } from "./deps.ts";
+import { decodeArrayStream, decodeAsync, encode } from "../mod.ts";
+
+// Downgrade stream not to implement AsycIterable<T>
+function downgradeReadableStream(stream: ReadableStream) {
+  // deno-lint-ignore no-explicit-any
+  (stream as any)[Symbol.asyncIterator] = undefined;
+}
+
+describe("whatwg streams", () => {
+  it("decodeArrayStream", async () => {
+    const data = [1, 2, 3];
+    const encoded = encode(data);
+    const stream = new ReadableStream({
+      // deno-lint-ignore no-explicit-any
+      start(controller: any) {
+        for (const byte of encoded) {
+          controller.enqueue([byte]);
+        }
+        controller.close();
+      },
+    });
+    downgradeReadableStream(stream);
+
+    const items: Array<unknown> = [];
+    for await (const item of decodeArrayStream(stream)) {
+      items.push(item);
+    }
+    assert.deepStrictEqual(items, data);
+  });
+
+  it("decodeAsync", async () => {
+    const data = [1, 2, 3];
+    const encoded = encode(data);
+    const stream = new ReadableStream({
+      // deno-lint-ignore no-explicit-any
+      start(controller: any) {
+        for (const byte of encoded) {
+          controller.enqueue([byte]);
+        }
+        controller.close();
+      },
+    });
+    downgradeReadableStream(stream);
+
+    assert.deepStrictEqual(await decodeAsync(stream), data);
+  });
+});

--- a/utils/stream.ts
+++ b/utils/stream.ts
@@ -39,7 +39,7 @@ export async function* asyncIterableFromStream<T>(
 }
 
 export function ensureAsyncIterabe<T>(
-  streamLike: ReadableStreamLike<T>,
+  streamLike: ReadableStreamLike<T> | AsyncGenerator<T, void, unknown>,
 ): AsyncIterable<T> {
   if (isAsyncIterable(streamLike)) {
     return streamLike;

--- a/utils/stream.ts
+++ b/utils/stream.ts
@@ -9,6 +9,7 @@ export type ReadableStreamLike<T> = AsyncIterable<T> | ReadableStream<T>;
 export function isAsyncIterable<T>(
   object: ReadableStreamLike<T>,
 ): object is AsyncIterable<T> {
+  // deno-lint-ignore no-explicit-any
   return (object as any)[Symbol.asyncIterator] != null;
 }
 

--- a/utils/utf8.ts
+++ b/utils/utf8.ts
@@ -88,15 +88,6 @@ export function utf8EncodeJs(
 const sharedTextEncoder = new TextEncoder();
 export const TEXT_ENCODER_THRESHOLD = 200;
 
-function utf8EncodeTEencode(
-  str: string,
-  output: Uint8Array,
-  outputOffset: number,
-): void {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  output.set(sharedTextEncoder!.encode(str), outputOffset);
-}
-
 function utf8EncodeTEencodeInto(
   str: string,
   output: Uint8Array,


### PR DESCRIPTION
Hi. I'm using this library to built [msgpack-rpc-deno](https://github.com/lambdalisue/msgpack-rpc-deno) (to built [denops.vim](https://github.com/vim-denops/denops.vim) which is an ecosystem of Vim/Neovim) and I'd love to improve the maintenanceability of this project as well. 

So, with this PR, I've

- Add GitHub Actions to perform lint/format/test to help keeping code quality
- Applied `deno fmt`
- Fix all warnings from `deno lint --unstable`
- (Partially) added the original tests and fix some types and exports
- ~Fix TS2729 on Deno 1.9 (I'm not sure why this happen but the applied code fix this type error)~
  - It seems the issue is already fixed by #3 so I've just revert the change

Thanks for your help.